### PR TITLE
Swap x/y only in portrait mode

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -183,9 +183,16 @@ hwc_display_pre_init(ScrnInfoPtr pScrn)
         pScrn->virtualY = pScrn->display->virtualY;
     } else {
         /* Pick rotated HWComposer screen resolution */
-        pScrn->virtualX = hwc->hwcHeight;
-        pScrn->virtualY = hwc->hwcWidth;
-     }
+        if (hwc->rotation == HWC_ROTATE_CW || hwc->rotation == HWC_ROTATE_CCW)
+        {
+	    /* portrait mode: swap x/y */
+   	    pScrn->virtualX = hwc->hwcHeight;
+            pScrn->virtualY = hwc->hwcWidth;
+        } else {
+            pScrn->virtualX = hwc->hwcWidth;
+            pScrn->virtualY = hwc->hwcHeight;
+        }
+    }
     pScrn->displayWidth = pScrn->virtualX;
 
     /* Construct a mode with the screen's initial dimensions */

--- a/src/display.c
+++ b/src/display.c
@@ -183,10 +183,9 @@ hwc_display_pre_init(ScrnInfoPtr pScrn)
         pScrn->virtualY = pScrn->display->virtualY;
     } else {
         /* Pick rotated HWComposer screen resolution */
-        if (hwc->rotation == HWC_ROTATE_CW || hwc->rotation == HWC_ROTATE_CCW)
-        {
-	    /* portrait mode: swap x/y */
-   	    pScrn->virtualX = hwc->hwcHeight;
+        if (hwc->rotation == HWC_ROTATE_CW || hwc->rotation == HWC_ROTATE_CCW) {
+            /* landscape mode on portrait panel: swap x/y */
+            pScrn->virtualX = hwc->hwcHeight;
             pScrn->virtualY = hwc->hwcWidth;
         } else {
             pScrn->virtualX = hwc->hwcWidth;


### PR DESCRIPTION
Hey,

this fixed landscape modes (normal and ud) for me. Otherwise x and y will be swapped unconditionally and you have to manually assign x and y as virtual resolution in a xorg config file.
I made the condition depended on CW and CCW as these are the only modes when x/y have to swapped. This way the if condition is correct, even if there will be more modes in the future (e.g. like vertical flip).